### PR TITLE
Adds source of Pods to remove deprecation notice

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,4 @@
+source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '7.0'
 
 pod 'pop'


### PR DESCRIPTION
As of CocoaPods 0.34, implicit sources are [deprecated](https://github.com/CocoaPods/CocoaPods/issues/2515). Adding the notice at the top of the podfile removes this notice.
